### PR TITLE
Fix for Internet Explorer's float outerWidth/outerHeight values

### DIFF
--- a/lib/jquery.simplemarquee.js
+++ b/lib/jquery.simplemarquee.js
@@ -174,7 +174,7 @@
                 'overflow': 'hidden',
             });
 
-            this._needsAnimation = this._element[0].scrollWidth > this._element.outerWidth();
+            this._needsAnimation = this._element[0].scrollWidth > Math.ceil(this._element.outerWidth());
         } else {
             this._element.css({
                 'word-wrap': 'break-word',      // Deprecated in favor of overflow wrap
@@ -183,7 +183,7 @@
                 'overflow': 'hidden',
             });
 
-            this._needsAnimation = this._element[0].scrollHeight > this._element.outerHeight();
+            this._needsAnimation = this._element[0].scrollHeight > Math.ceil(this._element.outerHeight());
         }
 
         this._element.toggleClass('has-enough-space', !this._needsAnimation);


### PR DESCRIPTION
I started using this plugin recently and noticed that for some reason in Internet Explorer the marquee is started regardless of the element overflowing or not. I narrowed it down to IE returning float values when calling `this._element.outerWidth()`, and the value is always between `this._element[0].scrollWidth-1` and `this._element[0].scrollWidth`.

Example: Adding `console.log(this._element[0].scrollWidth, this._element.outerWidth());` between lines [175-177](https://github.com/IndigoUnited/jquery.simplemarquee/blob/cfd5811/lib/jquery.simplemarquee.js#L175-L177) gave me this output:

```
275 265
175 174.0800018310547
135 134.08999633789062
204 203.10000610351562
```

Here the first set of values is for an element that does overflow and the rest for ones that do not. Adding `Math.ceil` to where I added them seems to fix this issue, and non-overflowing elements are correctly left alone.
